### PR TITLE
Potential fix for code scanning alert no. 6: Unvalidated dynamic method call

### DIFF
--- a/src/lib/tw-state-manager-hoc.jsx
+++ b/src/lib/tw-state-manager-hoc.jsx
@@ -263,7 +263,8 @@ const createRouter = (style, callbacks) => {
         style = 'hash';
     }
 
-    if (Object.prototype.hasOwnProperty.call(routers, style)) {
+    if (Object.prototype.hasOwnProperty.call(routers, style) &&
+        typeof routers[style] === 'function') {
         return new routers[style](callbacks);
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Glowing-Jellyfishings/scratch-gui/security/code-scanning/6](https://github.com/Glowing-Jellyfishings/scratch-gui/security/code-scanning/6)

The best way to fix this problem is to ensure two things before invoking `new routers[style](callbacks)`: (1) that the property `style` is both present as an own property on the `routers` object, and (2) that its value is actually a constructor function. This second check prevents runtime exceptions due to misconfigured or malicious values residing in the `routers` object. The fix should be applied in the definition of `createRouter` (around lines 266-268), by adding a check for `typeof routers[style] === 'function'`. If the value is not a constructor function, the function should throw an error or fall back to a known-safe router style. No functionality should otherwise be affected.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
